### PR TITLE
workaround for pmt header find (#14)

### DIFF
--- a/src/mpegts.cpp
+++ b/src/mpegts.cpp
@@ -136,7 +136,7 @@ bool MpegTS::read_table(int filter_pid, int filter_table)
 	raw_table_data.clear();
 	table_data.clear();
 
-	for(timeout = 0; timeout < 2000; timeout++)
+	for(timeout = 0; timeout < 4500; timeout++)
 	{
 		if(read(fd, (void *)&packet, sizeof(packet)) != sizeof(packet))
 			throw(trap("MpegTS::read_table: read error"));


### PR DESCRIPTION
use a higher timeout value to find pmt in movies which have the first pmt struct very late in the file